### PR TITLE
Add support for local files

### DIFF
--- a/lib/htmltoword/document.rb
+++ b/lib/htmltoword/document.rb
@@ -78,6 +78,7 @@ module Htmltoword
           unless @image_files.empty?
           #stream the image files into the media folder using open-uri
             @image_files.each do |hash|
+              print(hash[:url])
               out.put_next_entry("word/media/#{hash[:filename]}")
               out.write open(hash[:url]).read
             end

--- a/lib/htmltoword/document.rb
+++ b/lib/htmltoword/document.rb
@@ -82,7 +82,6 @@ module Htmltoword
               open(hash[:url], 'rb') do |f|
                 out.write(f.read)
               end
-              #out.write File.open(hash[:url], 'rb').read
             end
           end
         end

--- a/lib/htmltoword/document.rb
+++ b/lib/htmltoword/document.rb
@@ -78,9 +78,11 @@ module Htmltoword
           unless @image_files.empty?
           #stream the image files into the media folder using open-uri
             @image_files.each do |hash|
-              print(hash[:url])
               out.put_next_entry("word/media/#{hash[:filename]}")
-              out.write open(hash[:url]).read
+              open(hash[:url], 'rb') do |f|
+                out.write(f.read)
+              end
+              #out.write File.open(hash[:url], 'rb').read
             end
           end
         end


### PR DESCRIPTION
I found that I was not able to have local files read correctly. The entire file contents would only be read if the file was retrieved from a remote URL.

Changing the file to be read in a block as opposed to inline resulted in local files being correctly written.

I tested this change with both remote and local files and found that it works for both.
